### PR TITLE
fix(ios): Use layoutEffect in order to correctly render header buttons on iOS.

### DIFF
--- a/source/gui/screens/songlist/SongListScreen.tsx
+++ b/source/gui/screens/songlist/SongListScreen.tsx
@@ -33,9 +33,9 @@ const SongListScreen: React.FC<NativeStackScreenProps<ParamList, "SongList">> =
 
     React.useLayoutEffect(() => {
       navigation.setOptions({
-        headerRight: () => (<DeleteModeButton onPress={toggleDeleteMode}
-                                              onLongPress={clearAll}
-                                              isActivated={isDeleteMode} />)
+        headerRight: () => <DeleteModeButton onPress={toggleDeleteMode}
+                                             onLongPress={clearAll}
+                                             isActivated={isDeleteMode} />
       });
     }, [navigation, isDeleteMode]);
 

--- a/source/gui/screens/songs/song/SongDisplayScreen.tsx
+++ b/source/gui/screens/songs/song/SongDisplayScreen.tsx
@@ -97,7 +97,7 @@ const SongDisplayScreen: React.FC<ComponentProps> = ({ route, navigation }) => {
     }
   }, [song?.id]);
 
-  useEffect(() => {
+  React.useLayoutEffect(() => {
     if (song === undefined) {
       navigation.setOptions({
         title: "",

--- a/source/gui/screens/songs/song/VersePicker/VersePicker.tsx
+++ b/source/gui/screens/songs/song/VersePicker/VersePicker.tsx
@@ -31,7 +31,7 @@ const VersePicker: React.FC<ComponentProps> = ({ route, navigation }) => {
       styles.verseList.paddingHorizontal,
       versePickerItemStyles.container.minWidth));
 
-  useEffect(() => {
+  React.useLayoutEffect(() => {
     // Set the callback function for the button in this hook,
     // so the function will use the updated values. Strange behaviour, I know..
     navigation.setOptions({
@@ -135,7 +135,7 @@ const VersePicker: React.FC<ComponentProps> = ({ route, navigation }) => {
     navigation.navigate(routes.SongSearch);
   };
 
-  return (<View style={styles.container}>
+  return <View style={styles.container}>
     {verses !== undefined ? undefined : <Text>Failed to load verses</Text>}
     <ScrollView contentContainerStyle={styles.verseList}>
       {verses
@@ -147,7 +147,7 @@ const VersePicker: React.FC<ComponentProps> = ({ route, navigation }) => {
                                                    onPress={toggleVerse}
                                                    onLongPress={onItemLongPress} />)}
     </ScrollView>
-  </View>);
+  </View>;
 };
 
 export default VersePicker;


### PR DESCRIPTION
Bug was:
- open app
- enter song number
- long press song
- if song has > 5 verses, header checkmark button will disappear
