### PR TITLE
feat(documents): Added setting to prevent resetting path to root after viewing a document.

### DIFF
--- a/source/gui/screens/documents/search/DocumentSearchScreen.tsx
+++ b/source/gui/screens/documents/search/DocumentSearchScreen.tsx
@@ -3,6 +3,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useFocusEffect } from "@react-navigation/native";
 import { CollectionChangeCallback } from "realm";
 import { rollbar } from "../../../../logic/rollbar";
+import Settings from "../../../../settings";
 import Db from "../../../../logic/db/db";
 import { runAsync } from "../../../../logic/utils";
 import { DocumentGroup, Document } from "../../../../logic/db/models/Documents";
@@ -62,9 +63,11 @@ const DocumentSearchScreen: React.FC<NativeStackScreenProps<ParamList, typeof Do
   const onBlur = () => {
     isMounted = false;
     Db.documents.realm().objects<DocumentGroup>(DocumentGroupSchema.name).removeListener(onCollectionChange);
-    setGroup(undefined);
-    setRootGroups([]);
-    setSearchText("");
+    if (Settings.documentsResetPathToRoot) {
+      setGroup(undefined);
+      setRootGroups([]);
+      setSearchText("");
+    }
     setIsLoading(true);
   };
 

--- a/source/gui/screens/settings/SettingsScreen.tsx
+++ b/source/gui/screens/settings/SettingsScreen.tsx
@@ -249,6 +249,10 @@ const SettingsScreen: React.FC = () => {
                                     "the whole search phrase. This will yield more results."}
                                   keyName={"documentsMultiKeywordSearch"}
                                   isVisible={showAdvancedSettings} />
+          <SettingSwitchComponent title={"Reset search path"}
+                                  description={"After viewing a document, start browsing from the upper root instead of from where you left."}
+                                  keyName={"documentsResetPathToRoot"}
+                                  isVisible={showAdvancedSettings} />
 
           <Header title={"Other"} isVisible={showAdvancedSettings} />
           <SettingSwitchComponent title={"Share usage data"}

--- a/source/settings.ts
+++ b/source/settings.ts
@@ -35,6 +35,7 @@ class SettingsClass extends SettingsBaseClass {
   documentsMultiKeywordSearch = true;
   documentScale = 1.0;
   documentsUseExperimentalViewer = true;
+  documentsResetPathToRoot = false;
 
   // Server authentication
   authClientName = "";


### PR DESCRIPTION
fixes #159 
This reset is now disabled by default.