### PR TITLE
162 bugios button presses are not always recognized directly after screen change

### DIFF
--- a/source/gui/screens/settings/SettingsScreen.tsx
+++ b/source/gui/screens/settings/SettingsScreen.tsx
@@ -190,8 +190,12 @@ const SettingsScreen: React.FC = () => {
                                   keyName={"highlightSelectedVerses"}
                                   isVisible={showAdvancedSettings} />
           <SettingSwitchComponent title={"Remember previous song"}
-                                  description={"Show the previous song number in the search screen."}
+                                  description={"Show the previous viewed song number in the search screen."}
                                   keyName={"songSearchRememberPreviousEntry"}
+                                  isVisible={showAdvancedSettings} />
+          <SettingSwitchComponent title={"Clear search after adding/viewing a song"}
+                                  description={"Don't keep the previous search in the search screen."}
+                                  keyName={"clearSearchAfterAddedToSongList"}
                                   isVisible={showAdvancedSettings} />
           <SettingSwitchComponent title={"Animate scrolling"}
                                   description={"Disable this if scrolling isn't performing smooth."}
@@ -224,11 +228,6 @@ const SettingsScreen: React.FC = () => {
           <SettingSwitchComponent title={"Long press for menu"}
                                   description={"Long press the melody button will show the menu, instead of instant toggling the melody."}
                                   keyName={"longPressForMelodyMenu"}
-                                  isVisible={showAdvancedSettings} />
-
-          <Header title={"Song list"} isVisible={showAdvancedSettings} />
-          <SettingSwitchComponent title={"Clear search after adding song to song list"}
-                                  keyName={"clearSearchAfterAddedToSongList"}
                                   isVisible={showAdvancedSettings} />
 
           <Header title={"Documents"} />

--- a/source/gui/screens/songs/search/SearchScreen.tsx
+++ b/source/gui/screens/songs/search/SearchScreen.tsx
@@ -71,10 +71,10 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
     };
 
     const onBlur = () => {
-      if (Settings.clearSearchAfterAddedToSongList) {
-        // Use timeout to fix the bug on iOS that onLongPress doesn't get dismissed if the touch component gets unmounted
-        setTimeout(() => clearScreen(), 500);
-      }
+      if (!Settings.clearSearchAfterAddedToSongList) return;
+      // Use timeout to fix the bug on iOS that onLongPress doesn't get dismissed if the touch component gets unmounted
+      // This is still needed, even after #162
+      setTimeout(() => clearScreen(), 500);
     };
 
     useEffect(() => {

--- a/source/gui/screens/songs/search/SearchScreen.tsx
+++ b/source/gui/screens/songs/search/SearchScreen.tsx
@@ -27,7 +27,6 @@ import StringSearchButton from "./StringSearchButton";
 
 const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRoute>> =
   ({ navigation }) => {
-    const isNavigatingToVersePickerScreen = useRef<boolean>(false);
     const [inputValue, setInputValue] = useState("");
     const [previousInputValue, setPreviousInputValue] = useState("");
     const [results, setSearchResult] = useState<Array<Song>>([]);
@@ -71,11 +70,10 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
     };
 
     const onBlur = () => {
-      if (Settings.clearSearchAfterAddedToSongList || !isNavigatingToVersePickerScreen.current) {
+      if (Settings.clearSearchAfterAddedToSongList) {
         // Use timeout to fix the bug on iOS that onLongPress doesn't get dismissed if the touch component gets unmounted
         setTimeout(() => clearScreen(), 500);
       }
-      isNavigatingToVersePickerScreen.current = false;
     };
 
     const storeSelectedSongInformation = () => {
@@ -132,34 +130,6 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
       setSearchResult(results as unknown as Array<Song>);
     };
 
-    const onSearchResultItemPress = (song: Song) => {
-      storeSelectedSongInformation();
-      navigation.navigate(SongRoute, { id: song.id });
-    };
-
-    const onSearchResultItemLongPress = (song: Song) => {
-      storeSelectedSongInformation();
-      navigation.navigate(VersePickerRoute, {
-        verses: song.verses?.map(it => Verse.toObject(it)),
-        selectedVerses: [],
-        songId: song.id,
-        songName: song.name,
-        method: VersePickerMethod.ShowSong
-      });
-    };
-
-    const selectVersesAndAddToSongList = (song: Song) => {
-      storeSelectedSongInformation();
-      isNavigatingToVersePickerScreen.current = true;
-      navigation.navigate(VersePickerRoute, {
-        verses: song.verses?.map(it => Verse.toObject(it)),
-        selectedVerses: [],
-        songId: song.id,
-        songName: song.name,
-        method: VersePickerMethod.AddToSongListAndShowSearch
-      });
-    };
-
     const onAddedToSongList = () => {
       storeSelectedSongInformation();
       if (!Settings.clearSearchAfterAddedToSongList) return;
@@ -183,9 +153,7 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
     const renderSearchResultItem = ({ item }: { item: Song }) => (
       <SearchResultItem navigation={navigation}
                         song={item}
-                        onPress={onSearchResultItemPress}
-                        onLongPress={onSearchResultItemLongPress}
-                        onAddToSongListLongPress={selectVersesAndAddToSongList}
+                        beforeNavigating={storeSelectedSongInformation}
                         onAddedToSongList={onAddedToSongList}
                         showSongBundle={isTitleSimilarToOtherSongs(item, results)} />
     );

--- a/source/gui/screens/songs/search/SearchScreen.tsx
+++ b/source/gui/screens/songs/search/SearchScreen.tsx
@@ -27,6 +27,7 @@ import StringSearchButton from "./StringSearchButton";
 
 const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRoute>> =
   ({ navigation }) => {
+    const previousInputValueRef = useRef("");
     const [inputValue, setInputValue] = useState("");
     const [previousInputValue, setPreviousInputValue] = useState("");
     const [results, setSearchResult] = useState<Array<Song>>([]);
@@ -65,7 +66,7 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
     const onFocus = () => {
       setStringSearchButtonPlacement(Settings.stringSearchButtonPlacement);
       if (!Settings.songSearchRememberPreviousEntry) {
-        setPreviousInputValue("");
+        previousInputValueRef.current = "";
       }
     };
 
@@ -76,11 +77,17 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
       }
     };
 
+    useEffect(() => {
+      // We set the previousInputValue through the ref, as setting the state directly from within
+      // storeSelectedSongInformation, iOS will perform the longPress-won't-dismiss bug.
+      setPreviousInputValue(previousInputValueRef.current);
+    }, [previousInputValueRef.current]);
+
     const storeSelectedSongInformation = () => {
       if (!Settings.songSearchRememberPreviousEntry) {
-        setPreviousInputValue("");
+        previousInputValueRef.current = "";
       } else if (inputValue) {
-        setPreviousInputValue(inputValue);
+        previousInputValueRef.current = inputValue;
       }
     };
 
@@ -109,7 +116,7 @@ const SearchScreen: React.FC<BottomTabScreenProps<ParamList, typeof SongSearchRo
 
     const onClearKeyPress = () => {
       setInputValue("");
-      setPreviousInputValue("");
+      previousInputValueRef.current = "";
     };
 
     const fetchSearchResults = () => {

--- a/source/gui/screens/songs/song/HeaderIconVersePicker.tsx
+++ b/source/gui/screens/songs/song/HeaderIconVersePicker.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 const HeaderIconVersePicker: React.FC<Props> = ({ onPress }) => {
   return <HeaderIconButton icon={"list-ol"}
-                           onPress={onPress}
-                           hitSlop={{top: 10, right: 15, bottom: 10, left: 0}} />;
+                           onPress={() => requestAnimationFrame(onPress)}
+                           hitSlop={{ top: 10, right: 15, bottom: 10, left: 0 }} />;
 };
 
 export default HeaderIconVersePicker;

--- a/source/gui/screens/songs/song/SongDisplayScreen.tsx
+++ b/source/gui/screens/songs/song/SongDisplayScreen.tsx
@@ -100,6 +100,10 @@ const SongDisplayScreen: React.FC<ComponentProps> = ({ route, navigation }) => {
   useEffect(() => {
     verseHeights.current = {};
 
+    // If song is undefined, we're probably leaving this screen,
+    // so we can ignore state and animation updates.
+    if (song === undefined) return;
+
     if (Settings.songFadeIn) {
       animateSongFadeIn();
     }


### PR DESCRIPTION
In this PR, the 'previous input value' state is being updated in a less intrusive way, as this state updating caused the longPress action to hang on iOS. 

Side effect of this PR is that the 'clear search after added to song list' feature is replaced by the 'clear search after song viewed/added to song list' feature.