### PR TITLE
fix(audio): Treat song audio as music on iOS so it won't be muted by the hardware silence switch.

### DIFF
--- a/source/logic/songs/audiofiles/audiofiles.ts
+++ b/source/logic/songs/audiofiles/audiofiles.ts
@@ -37,7 +37,7 @@ export namespace AudioFiles {
       await TrackPlayer.setupPlayer({
         backBuffer: 120,
         androidAudioContentType: AndroidAudioContentType.Music,
-        iosCategory: IOSCategory.SoloAmbient,
+        iosCategory: IOSCategory.Playback,
         iosCategoryMode: IOSCategoryMode.Default
       });
     } catch (error) {


### PR DESCRIPTION
Fixes #300. Only tested on iPhone simulator. Issue might still persist on iPad, but I couldn't replicate it on the iPad simulator.